### PR TITLE
vendor patch: Bump GNOME release to 45

### DIFF
--- a/org.cockpit_project.CockpitClient.json
+++ b/org.cockpit_project.CockpitClient.json
@@ -1,7 +1,7 @@
 {
   "app-id": "org.cockpit_project.CockpitClient",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "43",
+  "runtime-version": "45",
   "sdk": "org.gnome.Sdk",
   "default-branch": "stable",
   "command": "cockpit-client",


### PR DESCRIPTION
Upstream: https://github.com/cockpit-project/cockpit/pull/19366