### PR TITLE
Plugin support

### DIFF
--- a/org.cockpit_project.CockpitClient.App.CockpitFiles.json
+++ b/org.cockpit_project.CockpitClient.App.CockpitFiles.json
@@ -1,0 +1,40 @@
+{
+  "app-id": "org.cockpit_project.CockpitClient.App.files",
+  "runtime": "org.cockpit_project.CockpitClient",
+  "runtime-version": "master",
+  "sdk": "org.gnome.Sdk//49",
+  "build-extension": true,
+  "finish-args": [
+    "--talk-name=org.freedesktop.Flatpak",
+    "--socket=wayland",
+    "--socket=fallback-x11",
+    "--device=dri",
+    "--share=ipc"
+  ],
+  "modules": [
+    {
+      "name": "cockpit-files",
+      "buildsystem": "simple",
+      "build-options": {
+        "env": {
+          "PREFIX": "files"
+        }
+      },
+      "build-commands": [
+        "make install"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://github.com/cockpit-project/cockpit-files/releases/download/35/cockpit-files-35.tar.xz",
+          "sha256": "084ab046c3f416f3bf0c0d7a4e0dc859bb31a99ba35cd6ce4391083f303784f3",
+          "x-checker-data": {
+            "type": "rotating-url",
+            "url": "https://github.com/cockpit-project/cockpit-files/releases/latest",
+            "pattern": "https://github.com/cockpit-project/cockpit-files/releases/download/([0-9.]+)/cockpit-files-([0-9.]+).tar.xz"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/org.cockpit_project.CockpitClient.json
+++ b/org.cockpit_project.CockpitClient.json
@@ -12,6 +12,16 @@
     "--device=dri",
     "--share=ipc"
   ],
+  "add-extensions": {
+    "org.cockpit_project.CockpitClient.App": {
+      "subdirectories": true,
+      "directory": "share/cockpit",
+      "version": "master",
+      "versions": "master",
+      "no-autodownload": true,
+      "autodelete": true
+    }
+  },
   "modules": [
     {
       "name": "cockpit-client",
@@ -39,62 +49,6 @@
         {
           "type": "file",
           "path": "org.cockpit_project.CockpitClient.releases.xml"
-        }
-      ]
-    },
-    {
-      "name": "cockpit-files",
-      "buildsystem": "simple",
-      "build-commands": [
-        "make install PREFIX=/app"
-      ],
-      "sources": [
-        {
-          "type": "archive",
-          "url": "https://github.com/cockpit-project/cockpit-files/releases/download/38/cockpit-files-38.tar.xz",
-          "sha256": "2bb0b84a09414881c08e50a2c6ddc7e9d1e8c5cda0a0c86e89d2f72f5593952d"
-        }
-      ]
-    },
-    {
-      "name": "cockpit-machines",
-      "buildsystem": "simple",
-      "build-commands": [
-        "make install PREFIX=/app"
-      ],
-      "sources": [
-        {
-          "type": "archive",
-          "url": "https://github.com/cockpit-project/cockpit-machines/releases/download/350/cockpit-machines-350.tar.xz",
-          "sha256": "ba9ce84a383727c8b4ae69dd3dec0f47e33495cf081d56ed5c959f1ba5426bc4"
-        }
-      ]
-    },
-    {
-      "name": "cockpit-ostree",
-      "buildsystem": "simple",
-      "build-commands": [
-        "make install PREFIX=/app"
-      ],
-      "sources": [
-        {
-          "type": "archive",
-          "url": "https://github.com/cockpit-project/cockpit-ostree/releases/download/222/cockpit-ostree-222.tar.xz",
-          "sha256": "b6991bc77fe8fe7322a0dee7ff45ec6ed562fcee773e74e1f009f17e1766dc2f"
-        }
-      ]
-    },
-    {
-      "name": "cockpit-podman",
-      "buildsystem": "simple",
-      "build-commands": [
-        "make install PREFIX=/app"
-      ],
-      "sources": [
-        {
-          "type": "archive",
-          "url": "https://github.com/cockpit-project/cockpit-podman/releases/download/123/cockpit-podman-123.tar.xz",
-          "sha256": "2935b230961725ba90fd4e132d492b56d702279591c8d8774e5015e9fb058990"
         }
       ]
     }


### PR DESCRIPTION
Allows plugin support, currently an experimentation without success.
Issue currently is the installation process and figuring out why
installing a plugin wipes the whole `share/cockpit` directory.

Signed-off-by: Freya Gustavsson <freya@venefilyn.se>
